### PR TITLE
Update compatible versions of python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,18 +7,16 @@ name = "p45-bluesky"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 description = "P45 specific bluesky plans and plan stubs "
 dependencies = [] # Add project dependencies here, e.g. ["click", "numpy"]
 dynamic = ["version"]
 license.file = "LICENSE"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
This module is intended to be compatible with latest version of dodal, in turn compatible with latest version of ophyd-async. Which follows the SPEC-0 standard- we therefore also are limited by SPEC-0.